### PR TITLE
Add free text input mode toggle for clip comments

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -9,7 +9,6 @@ document.addEventListener('DOMContentLoaded', function () {
 	let totalClips = 0;
 	let clipsPerPage = 0;
 	let labelOptions = []
-	let freeTextMode = false
 
 	// Utility: escape HTML to prevent XSS (string-based, no DOM allocation)
 	function escapeHtml(str) {
@@ -31,8 +30,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	csvPathInput.value = urlParams.get('csvPath') || '';
 	metadataInput.value = urlParams.get('metadata') || '';
 	labelOptionsInput.value = urlParams.get('labels') || '';
-	freeTextMode = urlParams.get('freeText') === 'true';
-	freeTextToggle.checked = freeTextMode;
+	freeTextToggle.checked = urlParams.get('freeText') === 'true';
 	const urlPage = urlParams.get('page');
 	if (urlPage) {
 		currentPage = Number(urlPage);
@@ -44,7 +42,7 @@ document.addEventListener('DOMContentLoaded', function () {
 		params.set('csvPath', csvPathInput.value);
 		params.set('metadata', metadataInput.value);
 		params.set('labels', labelOptionsInput.value);
-		params.set('freeText', freeTextMode);
+		params.set('freeText', freeTextToggle.checked);
 		params.set('page', currentPage);
 		window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
 	}
@@ -52,21 +50,20 @@ document.addEventListener('DOMContentLoaded', function () {
 	loadForm.addEventListener('submit', handleFormSubmit);
 
 	freeTextToggle.addEventListener('change', function () {
-		freeTextMode = freeTextToggle.checked;
 		updateUrlParams();
 		if (currentClips.length > 0) {
-			saveComments().then(() => {
-				// Re-fetch current clips to get updated comments, then re-render
-				axios.get(`/get_clips?page=${currentPage}`).then(response => {
-					currentClips = response.data.clips;
-					updateUI();
-					// Clear and rebuild preloaded next page
-					nextClips.length = 0;
-					nextClipElements.forEach(el => el.remove());
-					nextClipElements.length = 0;
-					preloadNextPage();
-				});
+			// Read current comment values from DOM before re-rendering
+			currentClips.forEach(clip => {
+				const el = document.getElementById(`comment-${clip.filename}`);
+				if (el) clip.comment = el.value;
 			});
+			updateUI();
+			// Rebuild preloaded next page elements with new widget type
+			nextClipElements.forEach(el => el.remove());
+			nextClipElements.length = 0;
+			if (nextClips.length > 0) {
+				createHiddenElements(nextClips);
+			}
 		}
 	});
 
@@ -176,7 +173,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 	const videoCardTemplate = (clip) => {
 		let commentHtml;
-		if (freeTextMode) {
+		if (freeTextToggle.checked) {
 			commentHtml = `<input type="text" id="comment-${clip.filename}" class="form-control" value="${escapeHtml(clip.comment)}">`;
 		} else {
 			const optionsHtml = labelOptions.map((optionText) => {

--- a/static/app.js
+++ b/static/app.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	let totalClips = 0;
 	let clipsPerPage = 0;
 	let labelOptions = []
+	let freeTextMode = false
 
 	// Utility: escape HTML to prevent XSS (string-based, no DOM allocation)
 	function escapeHtml(str) {
@@ -23,12 +24,15 @@ document.addEventListener('DOMContentLoaded', function () {
 	const csvPathInput = document.getElementById('csvPathInput');
 	const metadataInput = document.getElementById('metadataInput');
 	const labelOptionsInput = document.getElementById('labelOptionsInput');
+	const freeTextToggle = document.getElementById('freeTextToggle');
 
 	// Load values from URL query parameters and initialize inputs and currentPage
 	const urlParams = new URLSearchParams(window.location.search);
 	csvPathInput.value = urlParams.get('csvPath') || '';
 	metadataInput.value = urlParams.get('metadata') || '';
 	labelOptionsInput.value = urlParams.get('labels') || '';
+	freeTextMode = urlParams.get('freeText') === 'true';
+	freeTextToggle.checked = freeTextMode;
 	const urlPage = urlParams.get('page');
 	if (urlPage) {
 		currentPage = Number(urlPage);
@@ -40,11 +44,31 @@ document.addEventListener('DOMContentLoaded', function () {
 		params.set('csvPath', csvPathInput.value);
 		params.set('metadata', metadataInput.value);
 		params.set('labels', labelOptionsInput.value);
+		params.set('freeText', freeTextMode);
 		params.set('page', currentPage);
 		window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
 	}
 
 	loadForm.addEventListener('submit', handleFormSubmit);
+
+	freeTextToggle.addEventListener('change', function () {
+		freeTextMode = freeTextToggle.checked;
+		updateUrlParams();
+		if (currentClips.length > 0) {
+			saveComments().then(() => {
+				// Re-fetch current clips to get updated comments, then re-render
+				axios.get(`/get_clips?page=${currentPage}`).then(response => {
+					currentClips = response.data.clips;
+					updateUI();
+					// Clear and rebuild preloaded next page
+					nextClips.length = 0;
+					nextClipElements.forEach(el => el.remove());
+					nextClipElements.length = 0;
+					preloadNextPage();
+				});
+			});
+		}
+	});
 
 	// If URL already has parameters, auto-submit the form
 	if (csvPathInput.value) {
@@ -85,8 +109,8 @@ document.addEventListener('DOMContentLoaded', function () {
 				document.getElementById('clip-viewer').style.opacity = '1';
 			});
 
-		// load label options
-		labelOptions = labelOptionsInput.value.split(',');
+		// load label options: filter out empty entries, then prepend a single blank option
+		labelOptions = ['', ...labelOptionsInput.value.split(',').filter(s => s.trim() !== '')];
 	}
 
 	function showLoadingSpinner() {
@@ -151,12 +175,18 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 
 	const videoCardTemplate = (clip) => {
-		const optionsHtml = labelOptions.map((optionText) => {
-			const escaped = escapeHtml(optionText);
-			return clip.comment === optionText
-				? `<option value="${escaped}" selected>${escaped}</option>`
-				: `<option value="${escaped}">${escaped}</option>`;
-		}).join('');
+		let commentHtml;
+		if (freeTextMode) {
+			commentHtml = `<input type="text" id="comment-${clip.filename}" class="form-control" value="${escapeHtml(clip.comment)}">`;
+		} else {
+			const optionsHtml = labelOptions.map((optionText) => {
+				const escaped = escapeHtml(optionText);
+				return clip.comment === optionText
+					? `<option value="${escaped}" selected>${escaped}</option>`
+					: `<option value="${escaped}">${escaped}</option>`;
+			}).join('');
+			commentHtml = `<select id="comment-${clip.filename}" class="form-select">${optionsHtml}</select>`;
+		}
 
 		return `
 			<div class="col">
@@ -166,9 +196,7 @@ document.addEventListener('DOMContentLoaded', function () {
 					</div>
 					<div class="card-body ${escapeHtml(clip.clip_reviewed)}">
 						<p class="card-text">${escapeHtml(clip.metadata)}</p>
-						<select id="comment-${clip.filename}" class="form-select">
-							${optionsHtml}
-						</select>
+						${commentHtml}
 					</div>
 				</div>
 			</div>
@@ -276,7 +304,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 
 	function saveComments() {
-		if (currentClips.length === 0) return;
+		if (currentClips.length === 0) return Promise.resolve();
 
 		const comments = currentClips.map(clip => {
 			const el = document.getElementById(`comment-${clip.filename}`);
@@ -286,7 +314,7 @@ document.addEventListener('DOMContentLoaded', function () {
 			};
 		});
 
-		axios.post('/save_comments', comments)
+		return axios.post('/save_comments', comments)
 			.then(response => {
 				showAlert('Comments saved');
 			})

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -58,12 +58,18 @@
 			<div class="input-group me-2">
 				<span class="input-group-text">Options</span>
 				<input type="text" id="labelOptionsInput" class="form-control"
-					value=",PLAX_DEEP,PLAX,PLAX_ZOOM,RVINF,PSAX_PAP,PSAX_APEX,PSAX_MV,PSAX_AV,PSAX_AVZ,A4C,A4C_LV,A4C_ZOOM,A5C,A5C_ZOOM,A2C,A2C_LV,A2C_ZOOM,A3C,A3C_LV,A3C_ZOOM,SUBCOSTAL,SUPRASTERNAL,UNUSED,NOISE">
+					value="PLAX_DEEP,PLAX,PLAX_ZOOM,RVINF,PSAX_PAP,PSAX_APEX,PSAX_MV,PSAX_AV,PSAX_AVZ,A4C,A4C_LV,A4C_ZOOM,A5C,A5C_ZOOM,A2C,A2C_LV,A2C_ZOOM,A3C,A3C_LV,A3C_ZOOM,SUBCOSTAL,SUPRASTERNAL,UNUSED,NOISE">
 				<span class="input-group-text p-0">
 					<button type="button" class="btn btn-sm btn-link text-secondary" data-bs-toggle="tooltip" data-bs-placement="bottom"
-						title="Comma-separated list of label options for the dropdown on each clip. These are the choices available when classifying clips. A leading comma adds a blank option.">
+						title="Comma-separated list of label options for the dropdown on each clip. A blank option is always included as the default.">
 						<i class="fas fa-info-circle"></i>
 					</button>
+				</span>
+				<span class="input-group-text">
+					<div class="form-check form-switch mb-0">
+						<input class="form-check-input" type="checkbox" id="freeTextToggle">
+						<label class="form-check-label" for="freeTextToggle">Free text</label>
+					</div>
 				</span>
 			</div>
 			<button id="loadButton" type="submit" class="btn btn-primary">Load</button>


### PR DESCRIPTION
## Summary
This PR adds a toggle to switch between dropdown label selection and free text input for clip comments, with support for persisting the preference in URL parameters.

## Key Changes
- **Free text toggle UI**: Added a checkbox toggle in the form controls to switch between dropdown and text input modes
- **Dynamic widget rendering**: The `videoCardTemplate` now conditionally renders either a `<select>` dropdown or `<input type="text">` based on the `freeTextToggle` state
- **URL parameter persistence**: The free text preference is now saved to and loaded from URL query parameters (`freeText=true/false`)
- **State preservation on toggle**: When toggling between modes, the current comment values are read from the DOM before re-rendering to prevent data loss
- **Improved label options handling**: 
  - Removed the leading comma from default label options in the template
  - Modified the label parsing logic to automatically prepend a blank option and filter out empty entries
  - Updated the tooltip to reflect that a blank option is always included
- **Promise handling**: Updated `saveComments()` to return a Promise for better async flow control

## Implementation Details
- The free text toggle change event handler updates URL params, preserves current comments, re-renders the UI, and rebuilds preloaded next page elements with the new widget type
- Label options are now processed as: `['', ...labelOptionsInput.value.split(',').filter(s => s.trim() !== '')]` to ensure a blank option is always first
- Comment values are properly escaped in HTML to prevent XSS vulnerabilities

https://claude.ai/code/session_01Qbx489rbE9jUfBpxt4Pu1n