### PR TITLE
Replace page preloading with LRU cache for improved memory management

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2,8 +2,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
 	// State variables
 	let currentClips = [];
-	let nextClips = [];
-	let nextClipElements = [];
+	const pageCache = new Map();
+	const MAX_CACHE_SIZE = 7;
 	let currentPage = 0;
 	let totalPages = 0;
 	let totalClips = 0;
@@ -58,12 +58,9 @@ document.addEventListener('DOMContentLoaded', function () {
 				if (el) clip.comment = el.value;
 			});
 			updateUI();
-			// Rebuild preloaded next page elements with new widget type
-			nextClipElements.forEach(el => el.remove());
-			nextClipElements.length = 0;
-			if (nextClips.length > 0) {
-				createHiddenElements(nextClips);
-			}
+			// Clear cache so preloaded pages use the new widget type
+			pageCache.clear();
+			preloadAdjacentPages();
 		}
 	});
 
@@ -79,6 +76,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 
 	function loadCSV() {
+		pageCache.clear();
 		const csvPath = csvPathInput.value;
 		const metadataFields = metadataInput.value;
 
@@ -149,26 +147,44 @@ document.addEventListener('DOMContentLoaded', function () {
 	});
 	document.addEventListener('keydown', handleKeydown);
 
-	function fetchClips() {
-		axios.get(`/get_clips?page=${currentPage}`)
-			.then(response => {
-				currentClips = response.data.clips;
-				totalPages = response.data.total_pages;
-				totalClips = response.data.total_clips;
-				clipsPerPage = response.data.clips_per_page;
-				updateUI();
-				preloadNextPage();
-			});
+	function getCachedOrFetch(page) {
+		if (pageCache.has(page)) {
+			return Promise.resolve(pageCache.get(page));
+		}
+		return axios.get(`/get_clips?page=${page}`).then(response => {
+			pageCache.set(page, response.data);
+			evictCache(page);
+			return response.data;
+		});
 	}
 
-	function preloadNextPage() {
-		if (currentPage < totalPages - 1) {
-			axios.get(`/get_clips?page=${currentPage + 1}`)
-				.then(response => {
-					nextClips = response.data.clips;
-					createHiddenElements(nextClips);
-				});
+	function evictCache(nearPage) {
+		if (pageCache.size <= MAX_CACHE_SIZE) return;
+		const pages = Array.from(pageCache.keys());
+		pages.sort((a, b) => Math.abs(b - nearPage) - Math.abs(a - nearPage));
+		while (pageCache.size > MAX_CACHE_SIZE) {
+			pageCache.delete(pages.shift());
 		}
+	}
+
+	function preloadAdjacentPages() {
+		if (currentPage > 0 && !pageCache.has(currentPage - 1)) {
+			getCachedOrFetch(currentPage - 1);
+		}
+		if (currentPage < totalPages - 1 && !pageCache.has(currentPage + 1)) {
+			getCachedOrFetch(currentPage + 1);
+		}
+	}
+
+	function fetchClips() {
+		getCachedOrFetch(currentPage).then(data => {
+			currentClips = data.clips;
+			totalPages = data.total_pages;
+			totalClips = data.total_clips;
+			clipsPerPage = data.clips_per_page;
+			updateUI();
+			preloadAdjacentPages();
+		});
 	}
 
 	const videoCardTemplate = (clip, index) => {
@@ -201,72 +217,13 @@ document.addEventListener('DOMContentLoaded', function () {
 		`;
 	}
 
-	function createHiddenElements(clips) {
-		nextClipElements = [];
-		clips.forEach((clip, index) => {
-			const template = document.createElement('template');
-			template.innerHTML = videoCardTemplate(clip, index).trim();
-			const clipElement = template.content.firstChild;
-			clipElement.style.display = 'none';
-			nextClipElements.push(clipElement);
-			clipGrid.appendChild(clipElement);
-		});
-	}
-
 	function nextPage() {
 		if (currentPage < totalPages - 1) {
 			saveComments();
 			currentPage++;
 			updateUrlParams();
-			if (nextClips.length > 0 && nextClipElements.length > 0) {
-				swapInNextPage();
-			} else {
-				fetchClips();
-			}
+			fetchClips();
 		}
-	}
-
-	function swapInNextPage() {
-		// Remove current clips from DOM and clear from memory
-		Array.from(clipGrid.children).forEach(child => {
-			if (!nextClipElements.includes(child)) {
-				// Remove event listeners
-				child.onclick = null;
-				child.onmouseover = null;
-				child.onmouseout = null;
-
-				// Clear video source and pause playback
-				const video = child.querySelector('video');
-				if (video) {
-					video.pause();
-					video.src = '';
-					video.load();
-				}
-
-				// Remove child from DOM
-				child.remove();
-
-				// Clear any references in the child
-				if (child.player) {
-					child.player.dispose();
-					child.player = null;
-				}
-			}
-		});
-
-		// Show next clips
-		nextClipElements.forEach(element => {
-			element.style.display = '';
-		});
-
-		// Clear references
-		currentClips.length = 0;
-		currentClips = nextClips.slice(); // Create a shallow copy
-		nextClips.length = 0;
-		nextClipElements.length = 0;
-
-		updatePageInfo();
-		preloadNextPage();
 	}
 
 	function prevPage() {
@@ -306,11 +263,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
 		const comments = currentClips.map((clip, index) => {
 			const el = document.getElementById(`comment-${index}`);
-			return {
-				avi_path: clip.avi_path,
-				comment: el ? el.value : ''
-			};
+			const comment = el ? el.value : '';
+			clip.comment = comment;
+			return { avi_path: clip.avi_path, comment };
 		});
+
+		// Sync updated comments into the cache
+		if (pageCache.has(currentPage)) {
+			pageCache.get(currentPage).clips = currentClips.slice();
+		}
 
 		return axios.post('/save_comments', comments)
 			.then(response => {
@@ -359,6 +320,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	function updateUI() {
 		updatePageInfo();
 
+		clipGrid.querySelectorAll('video').forEach(v => { v.pause(); v.src = ''; });
 		clipGrid.innerHTML = '';
 		currentClips.forEach((clip, index) => {
 			const clipHtml = videoCardTemplate(clip, index);

--- a/static/app.js
+++ b/static/app.js
@@ -58,9 +58,6 @@ document.addEventListener('DOMContentLoaded', function () {
 				if (el) clip.comment = el.value;
 			});
 			updateUI();
-			// Clear cache so preloaded pages use the new widget type
-			pageCache.clear();
-			preloadAdjacentPages();
 		}
 	});
 
@@ -187,6 +184,8 @@ document.addEventListener('DOMContentLoaded', function () {
 			clipsPerPage = data.clips_per_page;
 			updateUI();
 			preloadAdjacentPages();
+		}).catch(() => {
+			showAlert('Error loading clips', 'danger');
 		});
 	}
 

--- a/static/app.js
+++ b/static/app.js
@@ -153,32 +153,35 @@ document.addEventListener('DOMContentLoaded', function () {
 		}
 		return axios.get(`/get_clips?page=${page}`).then(response => {
 			pageCache.set(page, response.data);
-			evictCache(page);
+			evictCache();
 			return response.data;
 		});
 	}
 
-	function evictCache(nearPage) {
-		if (pageCache.size <= MAX_CACHE_SIZE) return;
-		const pages = Array.from(pageCache.keys());
-		pages.sort((a, b) => Math.abs(b - nearPage) - Math.abs(a - nearPage));
+	function evictCache() {
 		while (pageCache.size > MAX_CACHE_SIZE) {
-			pageCache.delete(pages.shift());
+			let farthest = null;
+			let maxDist = -1;
+			for (const key of pageCache.keys()) {
+				const dist = Math.abs(key - currentPage);
+				if (dist > maxDist) { maxDist = dist; farthest = key; }
+			}
+			pageCache.delete(farthest);
 		}
 	}
 
 	function preloadAdjacentPages() {
 		if (currentPage > 0 && !pageCache.has(currentPage - 1)) {
-			getCachedOrFetch(currentPage - 1);
+			getCachedOrFetch(currentPage - 1).catch(() => {});
 		}
 		if (currentPage < totalPages - 1 && !pageCache.has(currentPage + 1)) {
-			getCachedOrFetch(currentPage + 1);
+			getCachedOrFetch(currentPage + 1).catch(() => {});
 		}
 	}
 
 	function fetchClips() {
 		getCachedOrFetch(currentPage).then(data => {
-			currentClips = data.clips;
+			currentClips = data.clips.map(c => ({...c}));
 			totalPages = data.total_pages;
 			totalClips = data.total_clips;
 			clipsPerPage = data.clips_per_page;
@@ -268,9 +271,9 @@ document.addEventListener('DOMContentLoaded', function () {
 			return { avi_path: clip.avi_path, comment };
 		});
 
-		// Sync updated comments into the cache
+		// Sync updated comments back into the cache
 		if (pageCache.has(currentPage)) {
-			pageCache.get(currentPage).clips = currentClips.slice();
+			pageCache.get(currentPage).clips = currentClips.map(c => ({...c}));
 		}
 
 		return axios.post('/save_comments', comments)


### PR DESCRIPTION
## Summary
Refactored the pagination system to use an LRU (Least Recently Used) cache instead of preloading and swapping DOM elements. This simplifies the codebase and improves memory efficiency by caching page data rather than maintaining hidden DOM elements.

## Key Changes
- **Replaced preloading mechanism**: Removed `nextClips` and `nextClipElements` state variables and replaced with `pageCache` (Map) and `MAX_CACHE_SIZE` constant
- **Implemented LRU cache**: Added `getCachedOrFetch()` function that returns cached page data if available, otherwise fetches from server
- **Added cache eviction**: Implemented `evictCache()` function that removes the page farthest from the current page when cache exceeds `MAX_CACHE_SIZE` (7 pages)
- **Simplified page navigation**: Replaced `swapInNextPage()` logic with straightforward `fetchClips()` calls that use the cache
- **Updated preloading strategy**: Changed `preloadNextPage()` to `preloadAdjacentPages()` which preloads both previous and next pages without creating hidden DOM elements
- **Improved cleanup**: Simplified `updateUI()` to pause and clear video sources before re-rendering instead of complex DOM manipulation
- **Enhanced comment persistence**: Updated `saveComments()` to sync comments back into the cache for consistency

## Notable Implementation Details
- Cache uses page numbers as keys and stores complete response data objects
- Eviction strategy prioritizes keeping pages closest to the current page in memory
- Preloading is now non-blocking with error handling (`.catch(() => {})`)
- Comments are synced back to cached data to maintain consistency across navigation
- Removed complex event listener cleanup and video disposal logic in favor of simpler DOM re-rendering

https://claude.ai/code/session_01QGyoiHV5Ufkuz4UjpiGYge