### PR TITLE
Add parquet support, auto-detect video path column, and read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## Features
 
+- Load clip lists from **CSV or Parquet** files
+- Auto-detects the video path column if `avi_path` is not present
 - Browse through a collection of video clips
 - View metadata for each clip
 - Add and save comments for individual clips
@@ -13,6 +15,7 @@
 - Navigate using previous/next buttons (including left and right keys on your keyboard) or jump to a specific page
 - Progress bar to show current position in the clip collection
 - Reviewed clips are highlighted
+- Graceful read-only mode when the file directory is not writable
 
 ## Setup
 
@@ -34,11 +37,12 @@ Open `http://localhost:8888` in your browser.
 | Option | Description | Default |
 |---|---|---|
 | `--port` | Port number | `8888` |
-| `--csv-dir` | Allowed directory for CSV files | Current working directory |
+| `--file-dir` | Allowed directory for CSV / Parquet files | Current working directory |
 | `--debug` | Use Flask dev server instead of gunicorn | Off |
 
 ## Notes
 
 - Videos are automatically converted to H.264 MP4 for cross-browser compatibility. Videos already in H.264/yuv420p format are served directly.
-- Annotations are stored in a SQLite database alongside the input CSV (e.g., `echoes_clipviewer.db`). Use "Export CSV" to download comments.
-- Comments are preserved when reloading the same CSV.
+- Annotations are stored in a SQLite database alongside the input file (e.g., `echoes_clipviewer.db`). Use "Export CSV" to download comments.
+- Comments are preserved when reloading the same file.
+- If the file directory is not writable, the database is stored in a temporary directory and a read-only indicator is shown.

--- a/app.py
+++ b/app.py
@@ -79,7 +79,9 @@ def get_db() -> sqlite3.Connection:
     """Open a DB connection from the session, or abort 400 if none loaded."""
     db_path = session.get("db_path")
     if not db_path or not os.path.isfile(db_path):
-        abort(400, description="No file loaded. Please load a CSV or Parquet file first.")
+        abort(
+            400, description="No file loaded. Please load a CSV or Parquet file first."
+        )
     conn = sqlite3.connect(db_path, timeout=10)
     conn.row_factory = sqlite3.Row
     return conn
@@ -101,6 +103,7 @@ def load_file():
     metadata_fields = [
         m.strip() for m in str(request.json["metadata_fields"]).split(",") if m.strip()
     ]
+    video_path_column = "avi_path"
 
     if not is_path_within(file_path, FILE_DIR):
         return jsonify(
@@ -111,12 +114,51 @@ def load_file():
     file_dir = os.path.dirname(os.path.realpath(file_path))
     read_only = not os.access(file_dir, os.W_OK)
 
-    # Skip re-processing if DB is already up-to-date
+    # Skip re-processing if DB is already up-to-date AND metadata fields match
     db_path = get_db_path(file_path, use_tmpdir=read_only)
+    requested_meta = ",".join(metadata_fields)
     try:
-        if os.path.isfile(db_path) and os.path.getmtime(db_path) >= os.path.getmtime(file_path):
-            session["db_path"] = db_path
-            return jsonify({"status": "success", "message": "File loaded successfully", "read_only": read_only})
+        if os.path.isfile(db_path) and os.path.getmtime(db_path) >= os.path.getmtime(
+            file_path
+        ):
+            with sqlite3.connect(db_path, timeout=10) as conn:
+                try:
+                    stored_meta = conn.execute(
+                        "SELECT key, value FROM meta WHERE key IN ('metadata_fields', 'source_file_path', 'video_path_column')"
+                    ).fetchall()
+                    stored = {k: v for k, v in stored_meta}
+                    if (
+                        stored.get("metadata_fields") == requested_meta
+                        and stored.get("source_file_path") == file_path
+                        and stored.get("video_path_column")
+                    ):
+                        session["db_path"] = db_path
+                        return jsonify(
+                            {
+                                "status": "success",
+                                "message": "File loaded successfully",
+                                "read_only": read_only,
+                            }
+                        )
+                except sqlite3.OperationalError:
+                    try:
+                        stored = conn.execute(
+                            "SELECT value FROM meta WHERE key = 'metadata_fields'"
+                        ).fetchone()
+                        if stored and stored[0] == requested_meta:
+                            session["db_path"] = db_path
+                            return jsonify(
+                                {
+                                    "status": "success",
+                                    "message": "File loaded successfully",
+                                    "read_only": read_only,
+                                }
+                            )
+                    except sqlite3.OperationalError:
+                        pass  # meta table missing (old DB) -- fall through to re-import
+                except Exception:
+                    pass
+
     except OSError:
         pass
 
@@ -139,6 +181,7 @@ def load_file():
                     "paths to existing video files with extensions: "
                     + ", ".join(sorted(VIDEO_EXTENSIONS))
                 )
+            video_path_column = detected
             df = df.rename({detected: "avi_path"})
 
         fieldnames = df.columns
@@ -162,7 +205,7 @@ def load_file():
         clip_rows = []
         for row in rows:
             metadata = (
-                ", ".join(f"{m}: {row.get(m, '')}" for m in metadata_fields)
+                "\n".join(f"{m}: {row.get(m, '')}" for m in metadata_fields)
                 if metadata_fields
                 else ""
             )
@@ -179,6 +222,24 @@ def load_file():
                     reviewed_at TEXT DEFAULT NULL
                 )
             """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL DEFAULT ''
+                )
+            """)
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES ('metadata_fields', ?)",
+                (requested_meta,),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES ('source_file_path', ?)",
+                (file_path,),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES ('video_path_column', ?)",
+                (video_path_column,),
+            )
 
             # Upsert: update metadata, preserve existing comments
             conn.executemany(
@@ -190,7 +251,13 @@ def load_file():
             )
 
         session["db_path"] = db_path
-        return jsonify({"status": "success", "message": "File loaded successfully", "read_only": read_only})
+        return jsonify(
+            {
+                "status": "success",
+                "message": "File loaded successfully",
+                "read_only": read_only,
+            }
+        )
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 400
 
@@ -263,15 +330,66 @@ def save_comments():
 @app.route("/export_comments")
 def export_comments():
     with get_db() as conn:
-        rows = conn.execute(
-            "SELECT avi_path, comment, reviewed_at FROM clips WHERE reviewed_at IS NOT NULL ORDER BY avi_path"
+        meta_rows = conn.execute(
+            "SELECT key, value FROM meta WHERE key IN ('source_file_path', 'video_path_column')"
         ).fetchall()
+        meta = {row["key"]: row["value"] for row in meta_rows}
+
+        source_file_path = meta.get("source_file_path")
+        video_path_column = meta.get("video_path_column")
+        if not source_file_path or not video_path_column:
+            abort(
+                400,
+                description="Missing export metadata. Reload the source file first.",
+            )
+
+        clip_rows = conn.execute(
+            "SELECT avi_path, comment, reviewed_at FROM clips"
+        ).fetchall()
+
+    if not os.path.isfile(source_file_path):
+        abort(400, description=f"Source file not found: {source_file_path}")
+
+    ext = os.path.splitext(source_file_path)[1].lower()
+    if ext == ".parquet":
+        df = pl.read_parquet(source_file_path)
+    else:
+        df = pl.read_csv(source_file_path)
+
+    source_columns = list(df.columns)
+    if video_path_column not in source_columns:
+        abort(
+            400,
+            description=f"Configured video path column '{video_path_column}' not found in source file.",
+        )
+
+    annotation_comment_col = "clipviewer_comment"
+    annotation_reviewed_col = "clipviewer_reviewed_at"
+    if (
+        annotation_comment_col in source_columns
+        or annotation_reviewed_col in source_columns
+    ):
+        abort(
+            400,
+            description="Source file already contains clipviewer export columns.",
+        )
+
+    comment_map = {
+        str(row["avi_path"]): (row["comment"], row["reviewed_at"] or "")
+        for row in clip_rows
+    }
+    source_rows = df.to_dicts()
 
     buf = io.StringIO()
     writer = csv.writer(buf)
-    writer.writerow(["avi_path", "comments", "reviewed_at"])
-    for row in rows:
-        writer.writerow([row["avi_path"], row["comment"], row["reviewed_at"] or ""])
+    writer.writerow(source_columns + [annotation_comment_col, annotation_reviewed_col])
+    for row in source_rows:
+        avi_path = row.get(video_path_column)
+        comment, reviewed_at = comment_map.get(str(avi_path), ("", ""))
+        writer.writerow(
+            ["" if row.get(col) is None else row.get(col) for col in source_columns]
+            + [comment, reviewed_at]
+        )
 
     return Response(
         buf.getvalue(),
@@ -291,13 +409,20 @@ def _is_browser_compatible(path: str) -> bool:
     try:
         result = subprocess.run(
             [
-                "ffprobe", "-v", "error",
-                "-select_streams", "v:0",
-                "-show_entries", "stream=codec_name,pix_fmt",
-                "-of", "csv=p=0",
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=codec_name,pix_fmt",
+                "-of",
+                "csv=p=0",
                 path,
             ],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         return result.stdout.strip() == "h264,yuv420p"
     except Exception:
@@ -392,20 +517,25 @@ def main(
                 super().__init__()
 
             def load_config(self):
+                if self.cfg is None:
+                    return
                 for key, value in self.options.items():
                     self.cfg.set(key, value)
 
             def load(self):
                 return self.application
 
-        GunicornApp(app, {
-            "bind": f"0.0.0.0:{port}",
-            "workers": 4,
-            "threads": 2,
-            "timeout": 300,
-            "preload_app": True,
-            "accesslog": "-",
-        }).run()
+        GunicornApp(
+            app,
+            {
+                "bind": f"0.0.0.0:{port}",
+                "workers": 4,
+                "threads": 2,
+                "timeout": 300,
+                "preload_app": True,
+                "accesslog": "-",
+            },
+        ).run()
 
 
 def cli() -> None:

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import tempfile
 import threading
 from pathlib import Path
 
+import polars as pl
 import typer
 from flask import (
     Flask,
@@ -29,7 +30,9 @@ from flask import (
 CLIPS_PER_PAGE = 6
 
 VIDEO_BASE = os.path.realpath("/")
-CSV_DIR = os.path.realpath(os.getcwd())
+FILE_DIR = os.path.realpath(os.getcwd())
+
+VIDEO_EXTENSIONS = {".avi", ".mp4", ".mov", ".mkv", ".wmv", ".flv", ".webm"}
 
 # Temp directory for converted MP4 files (for cross-browser compatibility)
 TMPDIR = tempfile.mkdtemp(prefix="clipviewer_")
@@ -49,16 +52,34 @@ def is_path_within(path: str, allowed_dir: str) -> bool:
     return Path(path).resolve().is_relative_to(allowed_dir)
 
 
-def get_db_path(csv_path: str) -> str:
-    base, _ = os.path.splitext(csv_path)
+def get_db_path(file_path: str, use_tmpdir: bool = False) -> str:
+    base, _ = os.path.splitext(file_path)
+    if use_tmpdir:
+        path_hash = hashlib.md5(file_path.encode()).hexdigest()
+        basename = os.path.basename(base)
+        return os.path.join(TMPDIR, f"{basename}_{path_hash}_clipviewer.db")
     return f"{base}_clipviewer.db"
+
+
+def detect_video_column(first_row: dict) -> str | None:
+    """Auto-detect which column contains video file paths by checking the first row."""
+    for col, value in first_row.items():
+        value = str(value).strip()
+        if not value:
+            continue
+        ext = os.path.splitext(value)[1].lower()
+        if ext not in VIDEO_EXTENSIONS:
+            continue
+        if os.path.isfile(os.path.join(VIDEO_BASE, value)):
+            return col
+    return None
 
 
 def get_db() -> sqlite3.Connection:
     """Open a DB connection from the session, or abort 400 if none loaded."""
     db_path = session.get("db_path")
     if not db_path or not os.path.isfile(db_path):
-        abort(400, description="No CSV loaded. Please load a CSV first.")
+        abort(400, description="No file loaded. Please load a CSV or Parquet file first.")
     conn = sqlite3.connect(db_path, timeout=10)
     conn.row_factory = sqlite3.Row
     return conn
@@ -74,46 +95,67 @@ def index():
     return render_template("index.jinja2")
 
 
-@app.route("/load_csv", methods=["POST"])
-def load_csv():
-    csv_path = str(request.json["csv_path"])
+@app.route("/load_file", methods=["POST"])
+def load_file():
+    file_path = str(request.json["file_path"])
     metadata_fields = [
         m.strip() for m in str(request.json["metadata_fields"]).split(",") if m.strip()
     ]
 
-    if not is_path_within(csv_path, CSV_DIR):
+    if not is_path_within(file_path, FILE_DIR):
         return jsonify(
-            {"status": "error", "message": "CSV path not in allowed directory"}
+            {"status": "error", "message": "File path not in allowed directory"}
         ), 403
 
+    # Check write access to determine read-only mode
+    file_dir = os.path.dirname(os.path.realpath(file_path))
+    read_only = not os.access(file_dir, os.W_OK)
+
     # Skip re-processing if DB is already up-to-date
-    db_path = get_db_path(csv_path)
+    db_path = get_db_path(file_path, use_tmpdir=read_only)
     try:
-        if os.path.isfile(db_path) and os.path.getmtime(db_path) >= os.path.getmtime(csv_path):
+        if os.path.isfile(db_path) and os.path.getmtime(db_path) >= os.path.getmtime(file_path):
             session["db_path"] = db_path
-            return jsonify({"status": "success", "message": "CSV loaded successfully"})
+            session["read_only"] = read_only
+            return jsonify({"status": "success", "message": "File loaded successfully", "read_only": read_only})
     except OSError:
         pass
 
     try:
-        # Read CSV
-        with open(csv_path, newline="") as f:
-            reader = csv.DictReader(f)
-            fieldnames = reader.fieldnames or []
-            rows = list(reader)
+        # Read CSV or Parquet using Polars
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext == ".parquet":
+            df = pl.read_parquet(file_path)
+        else:
+            df = pl.read_csv(file_path)
 
-        # Validate columns
-        required = set(metadata_fields + ["avi_path"])
-        missing = required - set(fieldnames)
-        if missing:
-            raise ValueError(f"CSV is missing columns: {', '.join(missing)}")
+        # Auto-detect video path column if avi_path is missing
+        if "avi_path" not in df.columns:
+            first_row = df.row(0, named=True) if len(df) > 0 else {}
+            detected = detect_video_column(first_row)
+            if detected is None:
+                raise ValueError(
+                    "No 'avi_path' column found, and no column could be auto-detected "
+                    "as containing video file paths. Ensure at least one column contains "
+                    "paths to existing video files with extensions: "
+                    + ", ".join(sorted(VIDEO_EXTENSIONS))
+                )
+            df = df.rename({detected: "avi_path"})
+
+        fieldnames = df.columns
+        rows = df.to_dicts()
+
+        # Validate metadata columns
+        missing_meta = set(metadata_fields) - set(fieldnames)
+        if missing_meta:
+            raise ValueError(f"File is missing columns: {', '.join(missing_meta)}")
 
         # Filter rows with avi_path
         rows = [r for r in rows if r.get("avi_path")]
 
         # Check video files (first 100)
         for row in rows[:100]:
-            video_path = os.path.join(VIDEO_BASE, row["avi_path"])
+            video_path = os.path.join(VIDEO_BASE, str(row["avi_path"]))
             if not os.path.isfile(video_path):
                 raise FileNotFoundError(f"Video file not found: {video_path}")
 
@@ -125,7 +167,7 @@ def load_csv():
                 if metadata_fields
                 else ""
             )
-            clip_rows.append((row["avi_path"], metadata))
+            clip_rows.append((str(row["avi_path"]), metadata))
 
         # Create/open database and import
         with sqlite3.connect(db_path, timeout=10) as conn:
@@ -149,8 +191,9 @@ def load_csv():
             )
 
         session["db_path"] = db_path
+        session["read_only"] = read_only
 
-        return jsonify({"status": "success", "message": "CSV loaded successfully"})
+        return jsonify({"status": "success", "message": "File loaded successfully", "read_only": read_only})
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 400
 
@@ -328,17 +371,17 @@ def serve_video(filename):
 
 def main(
     port: int = typer.Option(8888, help="Port number to run the server on."),
-    csv_dir: Path = typer.Option(
+    file_dir: Path = typer.Option(
         Path.cwd(),
-        help="Allowed directory for CSV files.",
+        help="Allowed directory for CSV / Parquet files.",
         exists=True,
         file_okay=False,
         resolve_path=True,
     ),
     debug: bool = typer.Option(False, help="Enable Flask debug mode."),
 ) -> None:
-    global CSV_DIR
-    CSV_DIR = str(csv_dir)
+    global FILE_DIR
+    FILE_DIR = str(file_dir)
 
     if debug:
         app.run(host="0.0.0.0", port=port, debug=True, threaded=True)

--- a/app.py
+++ b/app.py
@@ -116,7 +116,6 @@ def load_file():
     try:
         if os.path.isfile(db_path) and os.path.getmtime(db_path) >= os.path.getmtime(file_path):
             session["db_path"] = db_path
-    
             return jsonify({"status": "success", "message": "File loaded successfully", "read_only": read_only})
     except OSError:
         pass
@@ -191,8 +190,6 @@ def load_file():
             )
 
         session["db_path"] = db_path
-
-
         return jsonify({"status": "success", "message": "File loaded successfully", "read_only": read_only})
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 400

--- a/app.py
+++ b/app.py
@@ -116,7 +116,7 @@ def load_file():
     try:
         if os.path.isfile(db_path) and os.path.getmtime(db_path) >= os.path.getmtime(file_path):
             session["db_path"] = db_path
-            session["read_only"] = read_only
+    
             return jsonify({"status": "success", "message": "File loaded successfully", "read_only": read_only})
     except OSError:
         pass
@@ -191,7 +191,7 @@ def load_file():
             )
 
         session["db_path"] = db_path
-        session["read_only"] = read_only
+
 
         return jsonify({"status": "success", "message": "File loaded successfully", "read_only": read_only})
     except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "clipviewer"
 version = "0.1.0"
 description = "A simple web app for viewing and annotating video clips"
 requires-python = ">=3.10"
-dependencies = ["flask", "gunicorn", "typer"]
+dependencies = ["flask", "gunicorn", "typer", "polars"]
 
 [project.scripts]
 clipviewer = "app:cli"

--- a/static/app.js
+++ b/static/app.js
@@ -166,28 +166,25 @@ document.addEventListener('DOMContentLoaded', function () {
 		labelOptions = ['', ...labelOptionsInput.value.split(',').filter(s => s.trim() !== '')];
 	}
 
-	// Declared early; assigned after DOM refs are created below.
-	// Only called asynchronously (from the /load_file response handler),
-	// so the references are always initialised by the time this runs.
-	let _saveButton, _autoSaveIndicator;
-
+	// Called asynchronously (from the /load_file response handler), so
+	// saveButton and autoSaveIndicator are always initialised by call time.
 	function applyReadOnlyState() {
-		_saveButton.disabled = readOnly;
-		_saveButton.classList.toggle('btn-success', !readOnly);
-		_saveButton.classList.toggle('btn-secondary', readOnly);
+		saveButton.disabled = readOnly;
+		saveButton.classList.toggle('btn-success', !readOnly);
+		saveButton.classList.toggle('btn-secondary', readOnly);
 
-		_autoSaveIndicator.style.visibility = readOnly ? 'visible' : 'hidden';
-		_autoSaveIndicator.querySelector('i').className = readOnly ? 'bi bi-cloud-slash' : 'bi bi-cloud-check';
+		autoSaveIndicator.style.visibility = readOnly ? 'visible' : 'hidden';
+		autoSaveIndicator.querySelector('i').className = readOnly ? 'bi bi-cloud-slash' : 'bi bi-cloud-check';
 
 		const tooltipText = readOnly
 			? 'Saving is not possible — no write access to file directory'
 			: 'Auto-saved';
-		const tooltip = bootstrap.Tooltip.getInstance(_autoSaveIndicator);
+		const tooltip = bootstrap.Tooltip.getInstance(autoSaveIndicator);
 		if (tooltip) {
 			tooltip.setContent({ '.tooltip-inner': tooltipText });
 		} else if (readOnly) {
-			_autoSaveIndicator.setAttribute('title', tooltipText);
-			new bootstrap.Tooltip(_autoSaveIndicator);
+			autoSaveIndicator.setAttribute('title', tooltipText);
+			new bootstrap.Tooltip(autoSaveIndicator);
 		}
 
 		if (readOnly) {
@@ -225,7 +222,6 @@ document.addEventListener('DOMContentLoaded', function () {
 	const jumpToGo = document.getElementById('jumpToGo');
 	const progressClickArea = document.getElementById('progressClickArea');
 	const saveButton = document.getElementById('saveButton');
-	_saveButton = saveButton;
 	const pageInfo = document.getElementById('pageInfo');
 	const progressBar = document.getElementById('progressBar');
 	const clipGrid = document.getElementById('clipGrid');
@@ -481,7 +477,6 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 
 	const autoSaveIndicator = document.getElementById('autoSaveIndicator');
-	_autoSaveIndicator = autoSaveIndicator;
 
 	function showAutoSaveIndicator() {
 		if (readOnly) return;

--- a/static/app.js
+++ b/static/app.js
@@ -166,34 +166,32 @@ document.addEventListener('DOMContentLoaded', function () {
 		labelOptions = ['', ...labelOptionsInput.value.split(',').filter(s => s.trim() !== '')];
 	}
 
+	// Declared early; assigned after DOM refs are created below.
+	// Only called asynchronously (from the /load_file response handler),
+	// so the references are always initialised by the time this runs.
+	let _saveButton, _autoSaveIndicator;
+
 	function applyReadOnlyState() {
-		const saveBtn = document.getElementById('saveButton');
-		const indicator = document.getElementById('autoSaveIndicator');
+		_saveButton.disabled = readOnly;
+		_saveButton.classList.toggle('btn-success', !readOnly);
+		_saveButton.classList.toggle('btn-secondary', readOnly);
+
+		_autoSaveIndicator.style.visibility = readOnly ? 'visible' : 'hidden';
+		_autoSaveIndicator.querySelector('i').className = readOnly ? 'bi bi-cloud-slash' : 'bi bi-cloud-check';
+
+		const tooltipText = readOnly
+			? 'Saving is not possible — no write access to file directory'
+			: 'Auto-saved';
+		const tooltip = bootstrap.Tooltip.getInstance(_autoSaveIndicator);
+		if (tooltip) {
+			tooltip.setContent({ '.tooltip-inner': tooltipText });
+		} else if (readOnly) {
+			_autoSaveIndicator.setAttribute('title', tooltipText);
+			new bootstrap.Tooltip(_autoSaveIndicator);
+		}
 
 		if (readOnly) {
-			saveBtn.disabled = true;
-			saveBtn.classList.remove('btn-success');
-			saveBtn.classList.add('btn-secondary');
-			indicator.style.visibility = 'visible';
-			indicator.querySelector('i').className = 'bi bi-cloud-slash';
-			const tooltip = bootstrap.Tooltip.getInstance(indicator);
-			if (tooltip) {
-				tooltip.setContent({ '.tooltip-inner': 'Saving is not possible — no write access to file directory' });
-			} else {
-				indicator.setAttribute('title', 'Saving is not possible — no write access to file directory');
-				new bootstrap.Tooltip(indicator);
-			}
 			showAlert('Read-only mode: the file directory is not writable. Comments will be stored temporarily but will not persist.', 'warning');
-		} else {
-			saveBtn.disabled = false;
-			saveBtn.classList.remove('btn-secondary');
-			saveBtn.classList.add('btn-success');
-			indicator.style.visibility = 'hidden';
-			indicator.querySelector('i').className = 'bi bi-cloud-check';
-			const tooltip = bootstrap.Tooltip.getInstance(indicator);
-			if (tooltip) {
-				tooltip.setContent({ '.tooltip-inner': 'Auto-saved' });
-			}
 		}
 	}
 
@@ -227,6 +225,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	const jumpToGo = document.getElementById('jumpToGo');
 	const progressClickArea = document.getElementById('progressClickArea');
 	const saveButton = document.getElementById('saveButton');
+	_saveButton = saveButton;
 	const pageInfo = document.getElementById('pageInfo');
 	const progressBar = document.getElementById('progressBar');
 	const clipGrid = document.getElementById('clipGrid');
@@ -482,6 +481,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 
 	const autoSaveIndicator = document.getElementById('autoSaveIndicator');
+	_autoSaveIndicator = autoSaveIndicator;
 
 	function showAutoSaveIndicator() {
 		if (readOnly) return;
@@ -503,22 +503,17 @@ document.addEventListener('DOMContentLoaded', function () {
 
 		syncClipsToCache();
 
-		if (readOnly) {
-			// Still persist to temp DB for in-session navigation
-			return axios.post('/save_comments', comments).catch(() => {});
-		}
-
 		return axios.post('/save_comments', comments)
 			.then(response => {
+				if (readOnly) return;
 				if (silent) {
 					showAutoSaveIndicator();
 				} else {
-					const dbPath = response.data.db_path;
-					showAlert(`Comments saved to ${dbPath}`);
+					showAlert(`Comments saved to ${response.data.db_path}`);
 				}
 			})
 			.catch(() => {
-				if (!silent) showAlert('Error saving comments', 'danger');
+				if (!readOnly && !silent) showAlert('Error saving comments', 'danger');
 			});
 	}
 

--- a/static/app.js
+++ b/static/app.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	let totalClips = 0;
 	let clipsPerPage = 0;
 	let labelOptions = []
+	let readOnly = false;
 
 	// Utility: escape HTML to prevent XSS (string-based, no DOM allocation)
 	function escapeHtml(str) {
@@ -65,18 +66,18 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 
 	// ------------------------
-	// csv and metadata loading
+	// file and metadata loading
 	// ------------------------
 
 	const loadForm = document.getElementById('loadForm');
-	const csvPathInput = document.getElementById('csvPathInput');
+	const filePathInput = document.getElementById('filePathInput');
 	const metadataInput = document.getElementById('metadataInput');
 	const labelOptionsInput = document.getElementById('labelOptionsInput');
 	const freeTextToggle = document.getElementById('freeTextToggle');
 
 	// Load values from URL query parameters and initialize inputs and currentPage
 	const urlParams = new URLSearchParams(window.location.search);
-	csvPathInput.value = urlParams.get('csvPath') || '';
+	filePathInput.value = urlParams.get('filePath') || '';
 	metadataInput.value = urlParams.get('metadata') || '';
 	labelOptionsInput.value = urlParams.get('labels') || '';
 	freeTextToggle.checked = urlParams.get('freeText') === 'true';
@@ -88,7 +89,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	// Update URL with current form inputs and page number
 	function updateUrlParams() {
 		const params = new URLSearchParams();
-		params.set('csvPath', csvPathInput.value);
+		params.set('filePath', filePathInput.value);
 		params.set('metadata', metadataInput.value);
 		params.set('labels', labelOptionsInput.value);
 		params.set('freeText', freeTextToggle.checked);
@@ -120,24 +121,24 @@ document.addEventListener('DOMContentLoaded', function () {
 	});
 
 	// If URL already has parameters, auto-submit the form
-	if (csvPathInput.value) {
+	if (filePathInput.value) {
 		handleFormSubmit(new Event('submit'));
 	}
 
 	function handleFormSubmit(event) {
 		event.preventDefault();
 		updateUrlParams();
-		loadCSV();
+		loadFile();
 	}
 
-	function loadCSV() {
+	function loadFile() {
 		pageCache.clear();
 		clearDomCache();
-		const csvPath = csvPathInput.value;
+		const filePath = filePathInput.value;
 		const metadataFields = metadataInput.value;
 
-		if (!csvPath) {
-			showAlert('Please enter CSV path', 'danger');
+		if (!filePath) {
+			showAlert('Please enter a file path', 'danger');
 			return;
 		}
 
@@ -145,8 +146,10 @@ document.addEventListener('DOMContentLoaded', function () {
 		showLoadingSpinner();
 		document.getElementById('clip-viewer').style.opacity = '0.1';
 
-		axios.post('/load_csv', { csv_path: csvPath, metadata_fields: metadataFields })
-			.then(() => {
+		axios.post('/load_file', { file_path: filePath, metadata_fields: metadataFields })
+			.then((response) => {
+				readOnly = response.data.read_only || false;
+				applyReadOnlyState();
 				fetchClips();
 			})
 			.catch(error => {
@@ -161,6 +164,37 @@ document.addEventListener('DOMContentLoaded', function () {
 
 		// load label options: filter out empty entries, then prepend a single blank option
 		labelOptions = ['', ...labelOptionsInput.value.split(',').filter(s => s.trim() !== '')];
+	}
+
+	function applyReadOnlyState() {
+		const saveBtn = document.getElementById('saveButton');
+		const indicator = document.getElementById('autoSaveIndicator');
+
+		if (readOnly) {
+			saveBtn.disabled = true;
+			saveBtn.classList.remove('btn-success');
+			saveBtn.classList.add('btn-secondary');
+			indicator.style.visibility = 'visible';
+			indicator.querySelector('i').className = 'bi bi-cloud-slash';
+			const tooltip = bootstrap.Tooltip.getInstance(indicator);
+			if (tooltip) {
+				tooltip.setContent({ '.tooltip-inner': 'Saving is not possible — no write access to file directory' });
+			} else {
+				indicator.setAttribute('title', 'Saving is not possible — no write access to file directory');
+				new bootstrap.Tooltip(indicator);
+			}
+			showAlert('Read-only mode: the file directory is not writable. Comments will be stored temporarily but will not persist.', 'warning');
+		} else {
+			saveBtn.disabled = false;
+			saveBtn.classList.remove('btn-secondary');
+			saveBtn.classList.add('btn-success');
+			indicator.style.visibility = 'hidden';
+			indicator.querySelector('i').className = 'bi bi-cloud-check';
+			const tooltip = bootstrap.Tooltip.getInstance(indicator);
+			if (tooltip) {
+				tooltip.setContent({ '.tooltip-inner': 'Auto-saved' });
+			}
+		}
 	}
 
 	function showLoadingSpinner() {
@@ -450,6 +484,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	const autoSaveIndicator = document.getElementById('autoSaveIndicator');
 
 	function showAutoSaveIndicator() {
+		if (readOnly) return;
 		const timeStr = new Date().toLocaleTimeString('en-GB', { hour12: false });
 		autoSaveIndicator.style.visibility = 'visible';
 		const tooltip = bootstrap.Tooltip.getInstance(autoSaveIndicator);
@@ -467,6 +502,11 @@ document.addEventListener('DOMContentLoaded', function () {
 		});
 
 		syncClipsToCache();
+
+		if (readOnly) {
+			// Still persist to temp DB for in-session navigation
+			return axios.post('/save_comments', comments).catch(() => {});
+		}
 
 		return axios.post('/save_comments', comments)
 			.then(response => {

--- a/static/app.js
+++ b/static/app.js
@@ -21,8 +21,46 @@ document.addEventListener('DOMContentLoaded', function () {
 		return str.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
 	}
 
+	function formatMetadata(str) {
+		if (!str) return '';
+		return str.split('\n').map(field => {
+			const colonIdx = field.indexOf(': ');
+			if (colonIdx === -1) return escapeHtml(field);
+			const key = field.substring(0, colonIdx);
+			const value = field.substring(colonIdx + 2);
+			return `${escapeHtml(key)}: <strong>${escapeHtml(value)}</strong>`;
+		}).join('<br>');
+	}
+
 	function releaseVideos(container) {
 		container.querySelectorAll('video').forEach(v => { v.pause(); v.src = ''; });
+	}
+
+	function bindVideoLoadingStates(container) {
+		container.querySelectorAll('.video-container').forEach(videoContainer => {
+			const video = videoContainer.querySelector('video');
+			const spinner = videoContainer.querySelector('.video-spinner');
+			if (!video || !spinner) return;
+
+			if (video.readyState >= 2) {
+				spinner.classList.add('is-hidden');
+				return;
+			}
+
+			if (video.dataset.loadingBound === '1') return;
+			video.dataset.loadingBound = '1';
+
+			const hideSpinner = () => {
+				spinner.classList.add('is-hidden');
+				video.removeEventListener('loadeddata', hideSpinner);
+				video.removeEventListener('canplay', hideSpinner);
+				video.removeEventListener('error', hideSpinner);
+			};
+
+			video.addEventListener('loadeddata', hideSpinner, { once: true });
+			video.addEventListener('canplay', hideSpinner, { once: true });
+			video.addEventListener('error', hideSpinner, { once: true });
+		});
 	}
 
 	function removePreloadLinks(page) {
@@ -194,12 +232,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
 	function showLoadingSpinner() {
 		// Create and show the loading spinner
+		const spinnerOverlay = document.createElement('div');
+		spinnerOverlay.id = 'loading-spinner';
+
 		const spinner = document.createElement('div');
-		spinner.id = 'loading-spinner';
 		spinner.className = 'spinner-border text-primary';
 		spinner.setAttribute('role', 'status');
-		spinner.innerHTML = '<span class="sr-only">Loading...</span>';
-		document.body.appendChild(spinner);
+		spinner.setAttribute('aria-label', 'Loading');
+
+		spinnerOverlay.appendChild(spinner);
+		document.body.appendChild(spinnerOverlay);
 	}
 
 	function hideLoadingSpinner() {
@@ -334,6 +376,7 @@ document.addEventListener('DOMContentLoaded', function () {
 		clipGrid.appendChild(domCache.get(currentPage));
 		domCache.delete(currentPage);
 		removePreloadLinks(currentPage);
+		bindVideoLoadingStates(clipGrid);
 		clipGrid.querySelectorAll('video').forEach(v => { v.muted = true; v.play().catch(() => {}); });
 
 		applyPageData(pageCache.get(currentPage));
@@ -431,10 +474,13 @@ document.addEventListener('DOMContentLoaded', function () {
 			<div class="col">
 				<div class="card h-100">
 					<div class="video-container">
+						<div class="video-spinner" aria-hidden="true">
+							<div class="spinner-border spinner-border-sm" role="status"></div>
+						</div>
 						<video src="/video${escapeHtml(clip.avi_path)}" autoplay loop muted></video>
 					</div>
 					<div class="card-body ${escapeHtml(clip.clip_reviewed)}">
-						<p class="card-text">${escapeHtml(clip.metadata)}</p>
+						<p class="card-text">${formatMetadata(clip.metadata)}</p>
 						${commentHtml}
 					</div>
 				</div>
@@ -567,6 +613,7 @@ document.addEventListener('DOMContentLoaded', function () {
 			const clipHtml = videoCardTemplate(clip, index);
 			clipGrid.insertAdjacentHTML('beforeend', clipHtml);
 		});
+		bindVideoLoadingStates(clipGrid);
 		clipGrid.style.minHeight = '';
 	}
 

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,11 @@
+:root {
+	--video-placeholder-bg: rgb(233, 236, 239);
+}
+
+[data-bs-theme=dark] {
+	--video-placeholder-bg: rgb(42, 47, 54);
+}
+
 .theme-toggle-btn {
 	position: fixed;
 	top: 12px;
@@ -12,11 +20,12 @@
 }
 
 #loading-spinner {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 9999;
+	position: fixed;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 9999;
 }
 
 .alert {
@@ -56,6 +65,22 @@
 	position: relative;
 	width: 100%;
 	padding-bottom: 100%;
+	background-color: var(--video-placeholder-bg);
+	overflow: hidden;
+}
+
+.video-spinner {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1;
+	pointer-events: none;
+}
+
+.video-spinner.is-hidden {
+	display: none;
 }
 
 .video-container video {
@@ -76,4 +101,3 @@
 	/* these clips were already reviewed */
 	background-color: rgb(0, 42, 61);
 }
-

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -37,10 +37,10 @@
 		<form id="loadForm" class="mb-3 d-flex align-items-center justify-content-between">
 			<div class="input-group me-2">
 				<span class="input-group-text">Echos</span>
-				<input type="text" id="csvPathInput" class="form-control" placeholder="CSV file path">
+				<input type="text" id="filePathInput" class="form-control" placeholder="CSV / Parquet file path">
 				<span class="input-group-text p-0">
 					<button type="button" class="btn btn-sm btn-link text-secondary" data-bs-toggle="tooltip" data-bs-placement="bottom"
-						title="Path to the CSV file to load. The CSV must contain an avi_path column with the path to each video clip. Any additional columns can be displayed as metadata.">
+						title="Path to a CSV or Parquet file to load. The file should contain an avi_path column with the path to each video clip (or a column with video paths will be auto-detected). Any additional columns can be displayed as metadata.">
 						<i class="bi bi-info-circle"></i>
 					</button>
 				</span>

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "flask" },
     { name = "gunicorn" },
+    { name = "polars" },
     { name = "typer" },
 ]
 
@@ -51,6 +52,7 @@ dev = [
 requires-dist = [
     { name = "flask" },
     { name = "gunicorn" },
+    { name = "polars" },
     { name = "typer" },
 ]
 
@@ -229,6 +231,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.38.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/5e/208a24471a433bcd0e9a6889ac49025fd4daad2815c8220c5bd2576e5f1b/polars-1.38.1.tar.gz", hash = "sha256:803a2be5344ef880ad625addfb8f641995cfd777413b08a10de0897345778239", size = 717667, upload-time = "2026-02-06T18:13:23.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/737c1a6273c585719858261753da0b688454d1b634438ccba8a9c4eb5aab/polars-1.38.1-py3-none-any.whl", hash = "sha256:a29479c48fed4984d88b656486d221f638cba45d3e961631a50ee5fdde38cb2c", size = 810368, upload-time = "2026-02-06T18:11:55.819Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.38.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/4b/04d6b3fb7cf336fbe12fbc4b43f36d1783e11bb0f2b1e3980ec44878df06/polars_runtime_32-1.38.1.tar.gz", hash = "sha256:04f20ed1f5c58771f34296a27029dc755a9e4b1390caeaef8f317e06fdfce2ec", size = 2812631, upload-time = "2026-02-06T18:13:25.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a2/a00defbddadd8cf1042f52380dcba6b6592b03bac8e3b34c436b62d12d3b/polars_runtime_32-1.38.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:18154e96044724a0ac38ce155cf63aa03c02dd70500efbbf1a61b08cadd269ef", size = 44108001, upload-time = "2026-02-06T18:11:58.127Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/599ff3709e6a303024efd7edfd08cf8de55c6ac39527d8f41cbc4399385f/polars_runtime_32-1.38.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c49acac34cc4049ed188f1eb67d6ff3971a39b4af7f7b734b367119970f313ac", size = 40230140, upload-time = "2026-02-06T18:12:01.181Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8c/3ac18d6f89dc05fe2c7c0ee1dc5b81f77a5c85ad59898232c2500fe2ebbf/polars_runtime_32-1.38.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fef2ef2626a954e010e006cc8e4de467ecf32d08008f130cea1c78911f545323", size = 41994039, upload-time = "2026-02-06T18:12:04.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5a/61d60ec5cc0ab37cbd5a699edb2f9af2875b7fdfdfb2a4608ca3cc5f0448/polars_runtime_32-1.38.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8a5f7a8125e2d50e2e060296551c929aec09be23a9edcb2b12ca923f555a5ba", size = 45755804, upload-time = "2026-02-06T18:12:07.846Z" },
+    { url = "https://files.pythonhosted.org/packages/91/54/02cd4074c98c361ccd3fec3bcb0bd68dbc639c0550c42a4436b0ff0f3ccf/polars_runtime_32-1.38.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:10d19cd9863e129273b18b7fcaab625b5c8143c2d22b3e549067b78efa32e4fa", size = 42159605, upload-time = "2026-02-06T18:12:10.919Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f3/b2a5e720cc56eaa38b4518e63aa577b4bbd60e8b05a00fe43ca051be5879/polars_runtime_32-1.38.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61e8d73c614b46a00d2f853625a7569a2e4a0999333e876354ac81d1bf1bb5e2", size = 45336615, upload-time = "2026-02-06T18:12:14.074Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/ee2e4b7de948090cfb3df37d401c521233daf97bfc54ddec5d61d1d31618/polars_runtime_32-1.38.1-cp310-abi3-win_amd64.whl", hash = "sha256:08c2b3b93509c1141ac97891294ff5c5b0c548a373f583eaaea873a4bf506437", size = 45680732, upload-time = "2026-02-06T18:12:19.097Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/18/72c216f4ab0c82b907009668f79183ae029116ff0dd245d56ef58aac48e7/polars_runtime_32-1.38.1-cp310-abi3-win_arm64.whl", hash = "sha256:6d07d0cc832bfe4fb54b6e04218c2c27afcfa6b9498f9f6bbf262a00d58cc7c4", size = 41639413, upload-time = "2026-02-06T18:12:22.044Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Replace csv.DictReader with polars for reading both CSV and parquet files
- Auto-detect video path column when avi_path is missing by checking first
  row for columns with valid video file paths
- Handle read-only directories: write SQLite DB to temp dir, show warning
  notification, grey out save button, display bi-cloud-slash icon
- Rename csv-specific identifiers to generic file-based naming throughout
  (CSV_DIR→FILE_DIR, /load_csv→/load_file, csvPath→filePath, etc.)
- Update README with new features and CLI flag

https://claude.ai/code/session_01NHXqHs7QYix7KLwKVb7RHc